### PR TITLE
change bind.hpp header so it can compile in ubuntu 18

### DIFF
--- a/src/driver_svh/src/driver_svh/SVHController.cpp
+++ b/src/driver_svh/src/driver_svh/SVHController.cpp
@@ -40,7 +40,7 @@
 
 #include <driver_svh/Logging.h>
 #include <icl_comm/ByteOrderConversion.h>
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 
 using icl_comm::ArrayBuilder;
 

--- a/src/driver_svh/src/driver_svh/SVHSerialInterface.cpp
+++ b/src/driver_svh/src/driver_svh/SVHSerialInterface.cpp
@@ -31,7 +31,7 @@
 #include "driver_svh/Logging.h"
 
 #include <icl_comm/ByteOrderConversion.h>
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 
 using icl_core::TimeSpan;
 using icl_comm::serial::SerialFlags;


### PR DESCRIPTION
Placeholders such as '_1' or '_2' are not found.  They are included in "boost/bind.hpp":

using namespace boost::placeholders; 

This should be compatible with ubunu16.

